### PR TITLE
Фикс чтения KEP ключа при загрузке из контейнера Key-6.dat

### DIFF
--- a/library/cm-pkcs12/src/storage/file-storage.cpp
+++ b/library/cm-pkcs12/src/storage/file-storage.cpp
@@ -267,14 +267,18 @@ int FileStorage::decodeIit (const char* password)
     StoreBag* store_bag = nullptr;
 
     DO(pkcs8_decrypt(m_Buffer, password, &ba_privkeys[0], nullptr, nullptr));
-    DEBUG_OUTCON(printf("pkcs8_decrypt(iit), ba_privkey: ");ba_print(stdout, ba_privkeys[0]));
-
-    DO(pkcs12_get_kep_key(ba_privkeys[0], &ba_privkeys[1]));
+    DO(pkcs12_iit_read_kep_key(ba_privkeys[0], &ba_privkeys[1]));
 
     for (size_t i = 0; i < 2; i++) {
+        if (!ba_privkeys[i])
+            continue;
+
+        DEBUG_OUTCON(printf("pkcs8_decrypt(iit), ba_privkey[%d]: ", (int)i); ba_print(stdout, ba_privkeys[i]));
+
         CHECK_NOT_NULL(store_bag = new StoreBag());
         store_bag->setBagId(OID_PKCS12_P8_SHROUDED_KEY_BAG);
         store_bag->setData(StoreBag::BAG_TYPE::KEY, ba_privkeys[i]);
+
         ba_privkeys[i] = nullptr;
         addBag(store_bag);
         store_bag = nullptr;

--- a/library/cm-pkcs12/src/storage/pkcs12-utils.h
+++ b/library/cm-pkcs12/src/storage/pkcs12-utils.h
@@ -51,7 +51,7 @@ int pkcs12_add_p7encrypteddata (AuthenticatedSafe_t * authentSafe, const ByteArr
 int pkcs12_gen_macdata (const char * password, const char * hash, const size_t iterations,
         const ByteArray * baData, MacData_t ** macData);
 int pkcs12_write_pfx (const ByteArray * baAuthsafe, const MacData_t * macData, ByteArray ** baEncoded);
-int pkcs12_get_kep_key (const ByteArray * baPrivkey, ByteArray ** baKepPrivkey);
+int pkcs12_iit_read_kep_key(const ByteArray* baPrivkey, ByteArray** baKepPrivkey);
 
 
 #ifdef __cplusplus

--- a/library/common/pkix/oids.h
+++ b/library/common/pkix/oids.h
@@ -391,13 +391,20 @@ DEFINE_OID(OID_PKCS5_PBKDF2,            "1.2.840.113549.1.5.12");
 DEFINE_OID(OID_PKCS5_PBES2,             "1.2.840.113549.1.5.13");
 DEFINE_OID(OID_PBE_WITH_SHA1_TDES_CBC,  "1.2.840.113549.1.12.1.3");
 
-DEFINE_OID(OID_MEDOC_DIGEST,                "1.32.113549.1.7.1.524545");  // OID алгоритма хеширования MacData хранилища MEDOC PKCS12
-DEFINE_OID(OID_IIT_KEYSTORE,                "1.3.6.1.4.1.19398.1.1.1.2"); // OID хранилища закрытого ключа ИИТа KEY 6 DAT
-DEFINE_OID(OID_IIT_KEYSTORE_SIGN_KEYID,     "1.3.6.1.4.1.19398.1.1.2.1");
-DEFINE_OID(OID_IIT_KEYSTORE_KEP_SPKI,       "1.3.6.1.4.1.19398.1.1.2.2");
-DEFINE_OID(OID_IIT_KEYSTORE_KEP_PRIVKEY,    "1.3.6.1.4.1.19398.1.1.2.3");
-DEFINE_OID(OID_IIT_KEYSTORE_KEP_KEYID,      "1.3.6.1.4.1.19398.1.1.2.5");
-DEFINE_OID(OID_IIT_KEYSTORE_KEP_ENC_KEYID,  "1.3.6.1.4.1.19398.1.1.2.6");
+//-----------------------------------------------------------------------------------------
+//MEDOC
+DEFINE_OID(OID_MEDOC_DIGEST,            "1.32.113549.1.7.1.524545");  // OID алгоритма хеширования MacData хранилища MEDOC PKCS12
+
+//-----------------------------------------------------------------------------------------
+//IIT
+DEFINE_OID(OID_IIT_KEYSTORE,                     "1.3.6.1.4.1.19398.1.1.1.2"); // OID хранилища закрытого ключа IIT Key-6.dat
+DEFINE_OID(OID_IIT_KEYSTORE_ATTR_RSA_PRIVKEY,    "1.3.6.1.4.1.19398.1.1.1.5"); // RSA ключ ("почти" RSAPrivateKey из RFC 8017)
+DEFINE_OID(OID_IIT_KEYSTORE_ATTR_SIGN_KEYID,     "1.3.6.1.4.1.19398.1.1.2.1"); // Subject Key Identifier
+DEFINE_OID(OID_IIT_KEYSTORE_ATTR_KEP_SPKI,       "1.3.6.1.4.1.19398.1.1.2.2"); // Параметры KEP ключа
+DEFINE_OID(OID_IIT_KEYSTORE_ATTR_KEP_PRIVKEY,    "1.3.6.1.4.1.19398.1.1.2.3"); // KEP ключ
+DEFINE_OID(OID_IIT_KEYSTORE_ATTR_KEP_KEYID,      "1.3.6.1.4.1.19398.1.1.2.5"); // KEP Subject Key Identifier
+DEFINE_OID(OID_IIT_KEYSTORE_ATTR_HMAC_GOST34311, "1.3.6.1.4.1.19398.1.1.2.6"); // sbox (64 byte), key (8 byte), hash (32 byte)
+DEFINE_OID(OID_IIT_KEYSTORE_ATTR_RSA_KEYID,      "1.3.6.1.4.1.19398.1.1.2.7"); // RSA Subject Key Identifier
 
 //-----------------------------------------------------------------------------------------
 //PKCS7


### PR DESCRIPTION
Нужно свапать биты каждого байта ключа, а не свапать байты.

Также добавил несколько OID атрибутов Key-6.dat.