### PR TITLE
Fix compilation

### DIFF
--- a/library/uapki/src/content-hasher.cpp
+++ b/library/uapki/src/content-hasher.cpp
@@ -32,6 +32,7 @@
 #include "macros-internal.h"
 #include "uapkic-errors.h"
 #include "uapki-errors.h"
+#include <cstring>
 
 
 #define FILE_BLOCK_SIZE (10 * 1024 * 1024)


### PR DESCRIPTION
Without this patch:
```
[ 89%] Building CXX object _deps/uapki-build/uapki/CMakeFiles/uapki.dir/src/content-hasher.cpp.o
/app/out/_deps/uapki-src/library/uapki/src/content-hasher.cpp: In static member function 'static const uint8_t* UapkiNS::ContentHasher::baToPtr(const ByteArray*)':
/app/out/_deps/uapki-src/library/uapki/src/content-hasher.cpp:157:9: error: 'memcpy' was not declared in this scope
  157 |         memcpy(&rv_ptr, ba_get_buf_const(baPtr), sizeof(void*));
      |         ^~~~~~
/app/out/_deps/uapki-src/library/uapki/src/content-hasher.cpp:35:1: note: 'memcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
   34 | #include "uapki-errors.h"
  +++ |+#include <cstring>
   35 | 
```